### PR TITLE
Add a scope name(text.md)

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -11,7 +11,7 @@ module.exports = MarkdownImgHelper =
 				return unless editor
 				grammar = editor.getGrammar()
 				return unless grammar
-				return unless grammar.scopeName is 'source.gfm'
+				return unless grammar.scopeName in ['source.gfm', 'text.md']
 
 
 				clipboard = require 'clipboard'


### PR DESCRIPTION
The default scopeName of Markdown in Atom is `source.gfm` that provided by `language-gfm`. `language-markdown` is more smart than `language-gfm`. But, the scopeName provided`language-markdown` is `text.md`. So, add a new scopeName for image helper.

Signed-off-by: Ji.Tao jt6562@gmail.com
