### PR TITLE
Added markdown image syntax, including cursor move

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -61,8 +61,10 @@ module.exports = MarkdownImgHelper =
 			callback()
 
 	insertUrl: (url,editor) ->
-		editor.insertText(url)
-
+		editor.insertText('![')
+		pos = editor.getCursorBufferPosition()
+		editor.insertText('](' + url + ')')
+		editor.setCursorBufferPosition(pos)
 
 	deactivate: ->
 


### PR DESCRIPTION
Upon paste, the image syntax is added and the cursor is moved to 'alt text'.